### PR TITLE
Add DEFAULT_STREAMER fallback configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,34 @@ If you prefer to run from a local clone:
 }
 ```
 
+## Default Streamer Configuration
+
+Set the `DEFAULT_STREAMER` environment variable to automatically supply the `streamerName` argument for the `getStreamerByName`, `getQueue`, `getQueueStats`, and `monitorQueue` tools. These handlers fall back to the configured default when the argument is omitted, while still allowing you to override it by passing a `streamerName` explicitly. If neither the argument nor the environment variable is provided, the server will respond with an error.
+
+### Setting `DEFAULT_STREAMER` in Claude Desktop
+
+Add an `env` block to your Claude Desktop configuration when registering the server:
+
+```json
+{
+  "mcpServers": {
+    "streamersonglist": {
+      "command": "npx",
+      "args": ["streamersonglist-mcp"],
+      "env": {
+        "DEFAULT_STREAMER": "belleune"
+      }
+    }
+  }
+}
+```
+
+You can also set the variable for one-off terminal sessions:
+
+```bash
+DEFAULT_STREAMER=belleune npx streamersonglist-mcp
+```
+
 ## Tool Documentation
 
 ### getStreamerByName
@@ -137,7 +165,7 @@ If you prefer to run from a local clone:
 Fetch detailed information about a specific streamer.
 
 **Parameters:**
-- `streamerName` (string, required): The name of the streamer
+- `streamerName` (string, optional): The name of the streamer. Defaults to the `DEFAULT_STREAMER` environment variable when set.
 
 **Example:**
 ```
@@ -149,7 +177,7 @@ Use getStreamerByName with streamerName "belleune"
 View current song queues with pagination support.
 
 **Parameters:**
-- `streamerName` (string, required): The name of the streamer whose queue to fetch
+- `streamerName` (string, optional): The name of the streamer whose queue to fetch. Defaults to the `DEFAULT_STREAMER` environment variable when set.
 - `limit` (number, optional): Maximum number of songs to return (default: 50)
 - `offset` (number, optional): Number of songs to skip for pagination (default: 0)
 
@@ -163,7 +191,7 @@ Use getQueue with streamerName "belleune" and limit 10
 Get comprehensive stats about song queues.
 
 **Parameters:**
-- `streamerName` (string, required): The name of the streamer whose queue stats to fetch
+- `streamerName` (string, optional): The name of the streamer whose queue stats to fetch. Defaults to the `DEFAULT_STREAMER` environment variable when set.
 
 **Example:**
 ```
@@ -198,7 +226,7 @@ Use manageSongRequest to create a new request:
 Monitor queue changes with configurable polling intervals.
 
 **Parameters:**
-- `streamerName` (string, required): The name of the streamer whose queue to monitor
+- `streamerName` (string, optional): The name of the streamer whose queue to monitor. Defaults to the `DEFAULT_STREAMER` environment variable when set.
 - `interval` (number, optional): Polling interval in seconds (default: 30)
 - `duration` (number, optional): How long to monitor in seconds (default: 300)
 

--- a/src/server.js
+++ b/src/server.js
@@ -68,6 +68,8 @@ try {
 }
 
 // Create the server
+let defaultStreamer = process.env.DEFAULT_STREAMER || null;
+
 const server = new global.Server(
   {
     name: "streamersonglist-mcp",
@@ -93,7 +95,7 @@ const tools = [
           description: "The name of the streamer",
         },
       },
-      required: ["streamerName"],
+      required: [],
     },
   },
   {
@@ -117,7 +119,7 @@ const tools = [
           default: 0,
         },
       },
-      required: ["streamerName"],
+      required: [],
     },
   },
   {
@@ -131,7 +133,7 @@ const tools = [
           description: "The name of the streamer whose queue stats to fetch",
         },
       },
-      required: ["streamerName"],
+      required: [],
     },
   },
   {
@@ -194,7 +196,7 @@ const tools = [
           default: 300,
         },
       },
-      required: ["streamerName"],
+      required: [],
     },
   },
   {
@@ -358,10 +360,12 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
   try {
     switch (name) {
       case "getStreamerByName": {
-        const { streamerName } = args;
-        
+        const { streamerName = defaultStreamer } = args;
+
         if (!streamerName) {
-          throw new Error("streamerName is required");
+          throw new Error(
+            "streamerName is required. Provide a streamerName or set the DEFAULT_STREAMER environment variable."
+          );
         }
         
         try {
@@ -394,10 +398,12 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       }
 
       case "getQueue": {
-        const { streamerName, limit = 50, offset = 0 } = args;
-        
+        const { streamerName = defaultStreamer, limit = 50, offset = 0 } = args;
+
         if (!streamerName) {
-          throw new Error("streamerName is required");
+          throw new Error(
+            "streamerName is required. Provide a streamerName or set the DEFAULT_STREAMER environment variable."
+          );
         }
         
         try {
@@ -430,10 +436,12 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       }
 
       case "getQueueStats": {
-        const { streamerName } = args;
-        
+        const { streamerName = defaultStreamer } = args;
+
         if (!streamerName) {
-          throw new Error("streamerName is required");
+          throw new Error(
+            "streamerName is required. Provide a streamerName or set the DEFAULT_STREAMER environment variable."
+          );
         }
         
         try {
@@ -575,10 +583,12 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       }
 
       case "monitorQueue": {
-        const { streamerName, interval = 30, duration = 300 } = args;
-        
+        const { streamerName = defaultStreamer, interval = 30, duration = 300 } = args;
+
         if (!streamerName) {
-          throw new Error("streamerName is required");
+          throw new Error(
+            "streamerName is required. Provide a streamerName or set the DEFAULT_STREAMER environment variable."
+          );
         }
         
         try {


### PR DESCRIPTION
## Summary
- add a module-level default streamer that falls back to the `DEFAULT_STREAMER` environment variable when tool args omit `streamerName`
- relax the `getStreamerByName`, `getQueue`, `getQueueStats`, and `monitorQueue` schemas and handlers to use the fallback while still erroring if no streamer is available
- document how to configure `DEFAULT_STREAMER`, including Claude Desktop configuration examples

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c8e966fad083308014710fcb3cdf48