### PR TITLE
Fix handling of omitted tool arguments for default streamer flow

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -203,7 +203,8 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
 
 // Call tool handler
 server.setRequestHandler(CallToolRequestSchema, async (request) => {
-  const { name, arguments: args } = request.params;
+  const { name, arguments: rawArgs } = request.params;
+  const args = rawArgs ?? {};
 
   try {
     switch (name) {


### PR DESCRIPTION
## Summary
- default call-tool request arguments to an empty object before destructuring
- keep queue-related handlers working when streamerName is supplied by the default configuration

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68eadc08ed1c8330b7c273268c33b905