### PR TITLE
docs+chore: refresh docs, derive runtime version, centralize API base

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,11 +17,11 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 This is a **Model Context Protocol (MCP) server** that provides tools for interacting with StreamerSongList APIs. The server integrates with Claude Desktop and other MCP-compatible clients.
 
-**IMPORTANT**: Only 4 out of 11 documented API endpoints are functional in the live StreamerSongList API. See `docs/API_TESTING_REPORT.md` for detailed findings.
+Note: This server targets public, read-only endpoints of the StreamerSongList API. All implemented tools use real API responses (no simulated data). See `docs/API_TESTING_REPORT.md` for details.
 
 ### Key Dependencies
-- `@modelcontextprotocol/sdk@^1.13.3` - MCP protocol implementation
-- `undici@^7.11.0` - Modern fetch API implementation for Node.js
+- `@modelcontextprotocol/sdk@^1.20.0` - MCP protocol implementation
+- `undici@^7.16.0` - Modern fetch API implementation for Node.js
 
 ### Server Architecture
 - **Single-file implementation**: `src/server.js` (955 lines) contains the entire server
@@ -29,30 +29,29 @@ This is a **Model Context Protocol (MCP) server** that provides tools for intera
 - **Environment configuration**: Supports `DEFAULT_STREAMER` for convenient queue tool usage
 - **MCP Protocol**: Uses stdio transport for communication with Claude Desktop
 
-### Tool Categories
-
-#### ✅ Real API Data (3 tools)
-- **getStreamerByName**: Fetches comprehensive streamer configuration from `/v1/streamers/{name}`
-- **getQueue**: Retrieves current song queue from `/v1/streamers/{name}/queue`
-- **monitorQueue**: Monitors queue changes using real queue data (monitoring logic simulated)
-
-#### ⚠️ Simulated Data (1 tool)
-- **getQueueStats**: Returns realistic queue statistics (API endpoint `/v1/streamers/{name}/queue/stats` returns 404)
+### Available Tools (all real API data)
+- `getStreamerByName` — GET `/v1/streamers/{name}`
+- `getQueue` — GET `/v1/streamers/{name}/queue`
+- `getSongs` — GET `/v1/streamers/{name}/songs`
+- `searchSongs` — Client-side filtering over `getSongs`
+- `getSongDetails` — Client-side selection from `getSongs`
+- `monitorQueue` — Polls `getQueue` at intervals
 
 ### Environment Variable Support
-Set `DEFAULT_STREAMER` environment variable to automatically supply the streamerName argument for queue-related tools. Tools fall back to this default when the argument is omitted. You can also override it per-run with CLI flags such as `--streamer belleune`, `-s belleune`, or `-belleune` when starting the server.
+- `DEFAULT_STREAMER` — default streamer when `streamerName` is omitted (overridable via CLI `--streamer`)
+- `SSL_API_BASE` — override API base (default `https://api.streamersonglist.com/v1`)
+
+CLI overrides: `npx streamersonglist-mcp --streamer belleune`
 
 ### API Integration
-- **Base URL**: `https://api.streamersonglist.com`
-- **Working Endpoints**: 3 out of 4 implemented tools use real API endpoints
-- **Error Handling**: Graceful degradation with informative error messages
-- **No authentication required**: Simplified setup for available endpoints
-- **Missing Features**: Queue stats endpoint returns 404, handled with simulated data
+- Base URL: `https://api.streamersonglist.com/v1` (configurable via `SSL_API_BASE`)
+- All tools use real API endpoints; no authentication is required for public data
+- Error handling: consistent response checks and messages
 
-### Available API Endpoints
-- ✅ `GET /v1/streamers/{streamerName}` - Full streamer configuration
-- ✅ `GET /v1/streamers/{streamerName}/queue` - Current queue data
-- ❌ `GET /v1/streamers/{streamerName}/queue/stats` - Returns 404 (simulated)
+### Endpoints Used
+- `GET /v1/streamers/{streamerName}` — streamer configuration
+- `GET /v1/streamers/{streamerName}/queue` — current queue data
+- `GET /v1/streamers/{streamerName}/songs` — full catalog
 
 ### Development Patterns
 - **Tool Definition Pattern**: Each tool has comprehensive JSON Schema validation
@@ -69,4 +68,4 @@ Set `DEFAULT_STREAMER` environment variable to automatically supply the streamer
 - **No build process**: Published as source for maximum compatibility
 - **Binary entry**: `src/server.js` is both main file and CLI entry point
 - **Configuration example**: `claude-desktop-config.example.json` shows integration pattern
-- update CLAUDE.md with actual state of the mcp code
+ 

--- a/README.md
+++ b/README.md
@@ -50,22 +50,45 @@ npm start
 printf '{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}\n' | node src/server.js
 ```
 
-## Available Tools (4 Total)
+## Available Tools (6 Total)
 
-### ✅ Real API Data (3 tools)
+### ✅ All Real API Data (6 tools)
 - **getStreamerByName** — Fetch comprehensive streamer configuration
 - **getQueue** — List current song queue with pagination
+- **getSongs** — Fetch complete song list with pagination
+- **searchSongs** — Search songs by title or artist
+- **getSongDetails** — Get detailed information about a specific song
 - **monitorQueue** — Monitor queue changes using real data
 
-### ⚠️ Simulated Data (1 tool)
-- **getQueueStats** — Queue statistics (API endpoint returns 404, uses realistic mock data)
+### Usage Examples
+
+For comprehensive examples of how to use these tools, see **[docs/USAGE_EXAMPLES.md](./docs/USAGE_EXAMPLES.md)** including:
+
+- 🎵 Music discovery and analysis
+- 📊 Content creator tools and stream planning
+- 🤖 AI assistant integration and smart recommendations
+- 📈 Data analysis and insights
+- 🎪 Event planning and collaboration tools
+- 🛠️ Technical applications and automation
+
+Quick examples:
+```json
+// Search for songs
+{"tool": "searchSongs", "arguments": {"streamerName": "belleune", "query": "Frank Sinatra"}}
+
+// Get most popular songs
+{"tool": "getSongs", "arguments": {"streamerName": "belleune", "limit": 20}}
+
+// Compare streamer libraries
+{"tool": "getSongs", "arguments": {"streamerName": "vu_vu", "limit": 50}}
+```
 
 ## API Status
 
-**Working Endpoints**: 3 out of 4 implemented tools use real API data
-- Streamer information and queue management available
+**Working Endpoints**: All 6 tools use real API data
+- Streamer information, queue management, and full song library access
 - No authentication required for public endpoints
-- Queue statistics simulated (endpoint returns 404)
+- All features fully functional with real StreamerSongList API data
 
 For detailed API testing results, see [docs/API_TESTING_REPORT.md](./docs/API_TESTING_REPORT.md)
 

--- a/README.md
+++ b/README.md
@@ -115,6 +115,12 @@ DEFAULT_STREAMER=public_streamer npx streamersonglist-mcp
 npx streamersonglist-mcp --streamer public_streamer
 ```
 
+Configuration options:
+- `DEFAULT_STREAMER` — default streamer when an argument is omitted
+- `SSL_API_BASE` — override API base (default `https://api.streamersonglist.com/v1`)
+
+Version info: The server reports its version from `package.json`, matching the published package.
+
 Security tip: use only public streamer names; the server calls public read-only endpoints.
 
 ## Scripts
@@ -131,4 +137,3 @@ MIT — see `LICENSE`.
 ## Contributing
 
 PRs welcome. Please run `npm test` before submitting.
-

--- a/README.md
+++ b/README.md
@@ -136,4 +136,16 @@ MIT — see `LICENSE`.
 
 ## Contributing
 
-PRs welcome. Please run `npm test` before submitting.
+Contributions are welcome via pull requests. Due to limitations of the public StreamerSongList API, scope for major new features is intentionally modest — helpful contributions include:
+- Bug fixes, error handling, and robustness improvements
+- Documentation updates and examples
+- Small tooling or DX enhancements (tests, CI, config)
+
+Please open an issue to discuss larger ideas before starting work, and run `npm test` before submitting PRs.
+
+## Credits
+
+This project builds on the excellent StreamerSonglist service. All data and API functionality are provided by StreamerSonglist:
+- https://www.streamersonglist.com
+
+This project is community-maintained and not affiliated with or endorsed by StreamerSonglist.

--- a/claude-desktop-config.example.json
+++ b/claude-desktop-config.example.json
@@ -1,0 +1,12 @@
+{
+  "mcpServers": {
+    "streamersonglist": {
+      "command": "npx",
+      "args": ["streamersonglist-mcp"]
+    },
+    "streamersonglist-vu_vu": {
+      "command": "npx",
+      "args": ["streamersonglist-mcp", "-vu_vu"]
+    }
+  }
+}

--- a/docs/API_TESTING_REPORT.md
+++ b/docs/API_TESTING_REPORT.md
@@ -124,7 +124,7 @@ The existing MCP server (`src/server.js`) contains 11 tools, but only 4 have rea
 
 1. **`getStreamerByName`** ✅ - Fully functional
 2. **`getQueue`** ✅ - Fully functional
-3. **`getQueueStats`** ❌ - Returns simulated data
+3. **`getQueueStats`** ❌ - Not implemented by this server; upstream endpoint returns 404
 4. **`manageSongRequest`** ❌ - Returns simulated data
 5. **`monitorQueue`** ✅ - Works with real queue data
 6. **`getPlayHistory`** ❌ - Returns simulated data

--- a/docs/Enhanced-mcp.md
+++ b/docs/Enhanced-mcp.md
@@ -93,15 +93,15 @@ api.streamersonglist.com
 
 7. Default Streamer Handling & Safe Mode
 
-The existing MCP server supports a DEFAULT_STREAMER environment variable to simplify tool calls: if a user omits streamerName when invoking getQueue, getQueueStats or getStreamerByName, the server automatically uses the configured default
+The existing MCP server supports a DEFAULT_STREAMER environment variable to simplify tool calls: if a user omits streamerName when invoking tools (e.g., getQueue, getSongs, getStreamerByName), the server automatically uses the configured default.
 raw.githubusercontent.com
 . When enhancing the server, keep this behaviour for convenience but ensure it’s explicit and overridable:
 
-Expose a configuration interface (e.g., command line flag or GUI) to set or update DEFAULT_STREAMER without editing environment variables.
+Expose a configuration interface (e.g., command line flag or GUI) to set or update DEFAULT_STREAMER without editing environment variables. Also support overriding the API base with `SSL_API_BASE`.
 
 Validate default exists: on startup, call getStreamerByName with the default; if it returns 404, prompt for a valid name rather than failing silently.
 
-Allow overrides: even when DEFAULT_STREAMER is set, your enhanced tools (e.g., searchSongs or findSimilarSongs) should accept a streamerName parameter to override the default.
+Allow overrides: even when DEFAULT_STREAMER is set, tools accept a streamerName parameter to override the default. The server already implements `searchSongs` (client-side filter) and `getSongDetails` (client-side selection) atop `getSongs`.
 
 The branch codex/update-default-streamer-handling intentionally limits the server to public, read‑only GET endpoints for safety
 raw.githubusercontent.com

--- a/docs/README.md
+++ b/docs/README.md
@@ -31,3 +31,8 @@ These documentation files are primarily for:
 - ⚙️ Configuration: `DEFAULT_STREAMER`, `SSL_API_BASE`
 
 For most users, start with the project [README.md](../README.md). Developers can explore deeper docs here.
+
+## Contributing & Credits
+
+- Contributions are welcome via pull requests (docs, fixes, small enhancements). The upstream API has limited surface area, so large feature additions may be out of scope.
+- StreamerSonglist is the original service and API provider: https://www.streamersonglist.com. This project is not affiliated with or endorsed by StreamerSonglist.

--- a/docs/README.md
+++ b/docs/README.md
@@ -5,16 +5,15 @@ This directory contains detailed documentation for the StreamerSongList MCP Serv
 ## Files
 
 ### API Documentation
-- **[API_TESTING_REPORT.md](./API_TESTING_REPORT.md)** - Comprehensive API testing results and findings
-- **[API_DISCREPANCIES.md](./API_DISCREPANCIES.md)** - Analysis of documentation vs. actual API capabilities
-- **[SSLv1-keydata.md](./SSLv1-keydata.md)** - Original StreamerSongList API data models (for reference)
+- **[API_TESTING_REPORT.md](./API_TESTING_REPORT.md)** - API testing results and findings (public endpoints)
+- **[SSLv1-keydata.md](./SSLv1-keydata.md)** - StreamerSongList API data models (reference)
 
 ### Project Analysis
-- **[Enhanced-mcp.md](./Enhanced-mcp.md)** - Enhancement proposals and technical analysis
-- **[AGENTS.md](./AGENTS.md)** - AI agent integration strategies
+- **[Enhanced-mcp.md](./Enhanced-mcp.md)** - Enhancement proposals and technical notes
+- **[AGENTS.md](./AGENTS.md)** - Repository guidelines for contributors
 
 ### Research Materials
-- **API Endpoint Discovery Methods** - PDF research documents on API discovery techniques
+- API Endpoint Discovery Methods (PDFs) - Research on API discovery techniques
 
 ## Quick Reference
 
@@ -25,8 +24,10 @@ These documentation files are primarily for:
 - Understanding API limitations and capabilities
 - Research and development planning
 
-## API Status Summary
+## Status Summary
 
-- ✅ **4 endpoints working** with real data
-- ❌ **7+ endpoints documented but not available**
-- 📊 **Full testing report** available in API_TESTING_REPORT.md
+- ✅ Implemented tools use public, read-only API endpoints
+- 📦 Package publishes only `src/` for minimal installs
+- ⚙️ Configuration: `DEFAULT_STREAMER`, `SSL_API_BASE`
+
+For most users, start with the project [README.md](../README.md). Developers can explore deeper docs here.

--- a/docs/USAGE_EXAMPLES.md
+++ b/docs/USAGE_EXAMPLES.md
@@ -6,7 +6,7 @@ This document provides practical examples of how to use the StreamerSongList MCP
 
 - **getStreamerByName** - Fetch detailed streamer information
 - **getQueue** - View current song queue with pagination
-- **getQueueStats** - Get queue statistics
+ 
 - **monitorQueue** - Monitor queue changes over time
 - **getSongs** - Fetch complete song list with pagination
 - **searchSongs** - Search songs by title or artist
@@ -163,16 +163,8 @@ Monitor current queue status:
 }
 ```
 
-```json
-{
-  "tool": "getQueueStats",
-  "arguments": {
-    "streamerName": "belleune"
-  }
-}
-```
-
-**Use Case**: Understand queue health and viewer engagement
+ 
+Use case: For queue analytics, combine `getQueue` responses over time or use `monitorQueue` to observe changes.
 
 ## 🎯 Automated Workflows
 

--- a/docs/USAGE_EXAMPLES.md
+++ b/docs/USAGE_EXAMPLES.md
@@ -1,0 +1,633 @@
+# StreamerSongList MCP Server - Usage Examples
+
+This document provides practical examples of how to use the StreamerSongList MCP server's 7 tools for various use cases including music discovery, content creation, analytics, and automation.
+
+## Available Tools
+
+- **getStreamerByName** - Fetch detailed streamer information
+- **getQueue** - View current song queue with pagination
+- **getQueueStats** - Get queue statistics
+- **monitorQueue** - Monitor queue changes over time
+- **getSongs** - Fetch complete song list with pagination
+- **searchSongs** - Search songs by title or artist
+- **getSongDetails** - Get detailed information about a specific song
+
+## 🎵 Music Discovery & Analysis
+
+### Compare Streamer Music Libraries
+
+Discover different music tastes and preferences between streamers:
+
+```json
+{
+  "tool": "getSongs",
+  "arguments": {
+    "streamerName": "vu_vu",
+    "limit": 50
+  }
+}
+```
+
+```json
+{
+  "tool": "getSongs",
+  "arguments": {
+    "streamerName": "belleune",
+    "limit": 50
+  }
+}
+```
+
+**Use Case**: Compare music collections - vu_vu (266 songs, pop/rock) vs belleune (545 songs, jazz standards)
+
+### Find Similar Songs Across Streamers
+
+```json
+{
+  "tool": "searchSongs",
+  "arguments": {
+    "streamerName": "vu_vu",
+    "query": "Dua Lipa",
+    "limit": 10
+  }
+}
+```
+
+```json
+{
+  "tool": "searchSongs",
+  "arguments": {
+    "streamerName": "belleune",
+    "query": "Frank Sinatra",
+    "limit": 10
+  }
+}
+```
+
+**Use Case**: See which artists are popular across different streamers
+
+### Artist Popularity Analysis
+
+```json
+{
+  "tool": "searchSongs",
+  "arguments": {
+    "streamerName": "vu_vu",
+    "query": "Taylor Swift"
+  }
+}
+```
+
+```json
+{
+  "tool": "searchSongs",
+  "arguments": {
+    "streamerName": "belleune",
+    "query": "Ella Fitzgerald"
+  }
+}
+```
+
+**Use Case**: Analyze which artists dominate each streamer's library
+
+## 📊 Content Creator Tools
+
+### Stream Theme Planning
+
+Plan themed streams based on available music:
+
+```json
+{
+  "tool": "getSongs",
+  "arguments": {
+    "streamerName": "belleune",
+    "limit": 30
+  }
+}
+```
+
+**Use Case**: Jazz night - explore belleune's extensive jazz collection
+
+```json
+{
+  "tool": "searchSongs",
+  "arguments": {
+    "streamerName": "vu_vu",
+    "query": "rock",
+    "limit": 20
+  }
+}
+```
+
+**Use Case**: Rock night - find rock songs in vu_vu's library
+
+### Audience Request Management
+
+Check if requested songs are available:
+
+```json
+{
+  "tool": "searchSongs",
+  "arguments": {
+    "streamerName": "vu_vu",
+    "query": "Bohemian Rhapsody"
+  }
+}
+```
+
+Get detailed information about specific songs:
+
+```json
+{
+  "tool": "getSongDetails",
+  "arguments": {
+    "streamerName": "belleune",
+    "songId": 1940224
+  }
+}
+```
+
+**Use Case**: Verify song details before accepting viewer requests
+
+### Queue Analytics
+
+Monitor current queue status:
+
+```json
+{
+  "tool": "getQueue",
+  "arguments": {
+    "streamerName": "vu_vu",
+    "limit": 10
+  }
+}
+```
+
+```json
+{
+  "tool": "getQueueStats",
+  "arguments": {
+    "streamerName": "belleune"
+  }
+}
+```
+
+**Use Case**: Understand queue health and viewer engagement
+
+## 🎯 Automated Workflows
+
+### Daily Music Reports
+
+Generate daily summaries of most popular songs:
+
+```json
+{
+  "tool": "getSongs",
+  "arguments": {
+    "streamerName": "belleune",
+    "limit": 100
+  }
+}
+```
+
+**Use Case**: Extract top played songs for daily reports (sort by `timesPlayed` field)
+
+### Real-time Queue Monitoring
+
+```json
+{
+  "tool": "monitorQueue",
+  "arguments": {
+    "streamerName": "vu_vu",
+    "interval": 60,
+    "duration": 3600
+  }
+}
+```
+
+**Use Case**: Monitor queue changes during active streaming hours
+
+### Library Management
+
+Find duplicate or similar songs:
+
+```json
+{
+  "tool": "searchSongs",
+  "arguments": {
+    "streamerName": "vu_vu",
+    "query": "Love",
+    "limit": 20
+  }
+}
+```
+
+```json
+{
+  "tool": "searchSongs",
+  "arguments": {
+    "streamerName": "vu_vu",
+    "query": "Heart",
+    "limit": 20
+  }
+}
+```
+
+**Use Case**: Identify potential duplicates or themed song groups
+
+### Performance Tracking
+
+Track which songs get played most often:
+
+```json
+{
+  "tool": "getSongDetails",
+  "arguments": {
+    "streamerName": "belleune",
+    "songId": 1831207
+  }
+}
+```
+
+**Use Case**: Monitor performance of "La Vie En Rose" (64 plays)
+
+## 🤖 AI Assistant Integration
+
+### Smart Music Recommendations
+
+Claude can suggest songs based on context:
+
+**Weather-based suggestions:**
+```json
+{
+  "tool": "searchSongs",
+  "arguments": {
+    "streamerName": "belleune",
+    "query": "Rain",
+    "limit": 10
+  }
+}
+```
+
+**Time of day suggestions:**
+```json
+{
+  "tool": "searchSongs",
+  "arguments": {
+    "streamerName": "belleune",
+    "query": "Moon",
+    "limit": 10
+  }
+}
+```
+
+**Mood-based suggestions:**
+```json
+{
+  "tool": "searchSongs",
+  "arguments": {
+    "streamerName": "vu_vu",
+    "query": "Happy",
+    "limit": 10
+  }
+}
+```
+
+### Interactive Games
+
+**"Guess the Artist" games:**
+```json
+{
+  "tool": "searchSongs",
+  "arguments": {
+    "streamerName": "vu_vu",
+    "query": "Queen"
+  }
+}
+```
+
+```json
+{
+  "tool": "searchSongs",
+  "arguments": {
+    "streamerName": "vu_vu",
+    "query": "Beatles"
+  }
+}
+```
+
+**"Music Trivia" with themed questions:**
+```json
+{
+  "tool": "searchSongs",
+  "arguments": {
+    "streamerName": "belleune",
+    "query": "Love",
+    "limit": 15
+  }
+}
+```
+
+```json
+{
+  "tool": "searchSongs",
+  "arguments": {
+    "streamerName": "belleune",
+    "query": "River",
+    "limit": 10
+  }
+}
+```
+
+## 📈 Data Analysis & Insights
+
+### Genre Distribution Analysis
+
+Analyze music preferences by streamer:
+
+```json
+{
+  "tool": "getSongs",
+  "arguments": {
+    "streamerName": "vu_vu",
+    "limit": 50
+  }
+}
+```
+
+**Expected Pattern**: Pop/rock/modern music
+
+```json
+{
+  "tool": "getSongs",
+  "arguments": {
+    "streamerName": "belleune",
+    "limit": 50
+  }
+}
+```
+
+**Expected Pattern**: Jazz standards and classics
+
+### Engagement Metrics
+
+See which songs drive audience engagement:
+
+```json
+{
+  "tool": "getQueue",
+  "arguments": {
+    "streamerName": "vu_vu"
+  }
+}
+```
+
+**Use Case**: What songs are currently requested by viewers
+
+```json
+{
+  "tool": "getSongDetails",
+  "arguments": {
+    "streamerName": "belleune",
+    "songId": 1831207
+  }
+}
+```
+
+**Use Case**: Analyze most popular song performance (64 plays)
+
+### Trend Analysis
+
+Monitor music trends over time:
+
+```json
+{
+  "tool": "monitorQueue",
+  "arguments": {
+    "streamerName": "vu_vu",
+    "interval": 300,
+    "duration": 7200
+  }
+}
+```
+
+**Use Case**: 2-hour monitoring during peak streaming time
+
+```json
+{
+  "tool": "searchSongs",
+  "arguments": {
+    "streamerName": "belleune",
+    "query": "2024",
+    "limit": 20
+  }
+}
+```
+
+**Use Case**: Find recently added songs from 2024
+
+## 🎪 Event Planning
+
+### Special Occasion Streams
+
+**Birthday celebration streams:**
+```json
+{
+  "tool": "searchSongs",
+  "arguments": {
+    "streamerName": "belleune",
+    "query": "Happy",
+    "limit": 10
+  }
+}
+```
+
+```json
+{
+  "tool": "searchSongs",
+  "arguments": {
+    "streamerName": "vu_vu",
+    "query": "Celebration",
+    "limit": 10
+  }
+}
+```
+
+**Holiday-themed streams:**
+```json
+{
+  "tool": "searchSongs",
+  "arguments": {
+    "streamerName": "belleune",
+    "query": "Christmas",
+    "limit": 15
+  }
+}
+```
+
+```json
+{
+  "tool": "searchSongs",
+  "arguments": {
+    "streamerName": "vu_vu",
+    "query": "Halloween",
+    "limit": 10
+  }
+}
+```
+
+### Collaboration Planning
+
+Find common songs between streamers for collaborations:
+
+```json
+{
+  "tool": "getSongs",
+  "arguments": {
+    "streamerName": "vu_vu",
+    "limit": 100
+  }
+}
+```
+
+```json
+{
+  "tool": "getSongs",
+  "arguments": {
+    "streamerName": "belleune",
+    "limit": 100
+  }
+}
+```
+
+**Use Case**: Claude can compare results and suggest collaboration-compatible songs
+
+## 🛠️ Technical Applications
+
+### Database Backup & Export
+
+Export complete song libraries for backup:
+
+```json
+{
+  "tool": "getSongs",
+  "arguments": {
+    "streamerName": "belleune",
+    "limit": 545
+  }
+}
+```
+
+**Use Case**: Full library backup (545 songs)
+
+```json
+{
+  "tool": "getSongs",
+  "arguments": {
+    "streamerName": "vu_vu",
+    "limit": 266
+  }
+}
+```
+
+**Use Case**: Full library backup (266 songs)
+
+### API Health Monitoring
+
+Test API endpoints and response times:
+
+```json
+{
+  "tool": "getStreamerByName",
+  "arguments": {
+    "streamerName": "vu_vu"
+  }
+}
+```
+
+```json
+{
+  "tool": "getQueue",
+  "arguments": {
+    "streamerName": "belleune"
+  }
+}
+```
+
+**Use Case**: Verify API functionality and performance
+
+### Configuration Validation
+
+Verify streamer setup and permissions:
+
+```json
+{
+  "tool": "getStreamerByName",
+  "arguments": {
+    "streamerName": "vu_vu"
+  }
+}
+```
+
+```json
+{
+  "tool": "getStreamerByName",
+  "arguments": {
+    "streamerName": "belleune"
+  }
+}
+```
+
+**Use Case**: Check streamer configuration, attributes, and permissions
+
+## 💡 Pro Tips
+
+### Pagination Strategy
+- Use `limit` and `offset` parameters for large libraries
+- Start with small limits (10-20) for discovery
+- Use larger limits (100+) for full analysis
+
+### Search Optimization
+- Use lowercase queries for case-insensitive search
+- Try partial artist names (e.g., "Sinatra" instead of "Frank Sinatra")
+- Combine search terms to narrow results
+
+### Performance Considerations
+- Cache results for frequently accessed data
+- Use monitoring tools sparingly to avoid API rate limits
+- Batch requests when possible for efficiency
+
+### Error Handling
+- Always check if streamer exists before accessing song data
+- Handle cases where songs might not be found
+- Validate song IDs before requesting details
+
+## 🚀 Advanced Use Cases
+
+### Automated Content Generation
+Generate weekly "Top 10" lists based on play counts:
+```json
+{
+  "tool": "getSongs",
+  "arguments": {
+    "streamerName": "belleune",
+    "limit": 200
+  }
+}
+```
+Process results to extract and sort by `timesPlayed` field
+
+### Cross-Platform Integration
+Combine with other APIs to create rich music experiences:
+- Weather APIs for mood-based suggestions
+- Calendar APIs for event-specific playlists
+- Social media APIs for trending songs
+
+### Machine Learning Applications
+Use song data for:
+- Recommendation algorithms
+- Genre classification
+- Listener behavior analysis
+- Predictive queue management
+
+The StreamerSongList MCP server provides powerful programmatic access to streamer music libraries, enabling endless possibilities for automation, analysis, content creation, and AI-powered music experiences!

--- a/docs/analysis-reports/2025-10-12-streamersonglist-mcp-architecture-report.md
+++ b/docs/analysis-reports/2025-10-12-streamersonglist-mcp-architecture-report.md
@@ -1,0 +1,342 @@
+---
+title: "StreamerSongList MCP — Code-First Architecture Report"
+summary: "A Model Context Protocol (MCP) server that provides read-only access to StreamerSongList API data through 6 tools, built as a single-file Node.js application with dynamic SDK loading and optional default streamer configuration."
+metatags: [architecture, code-analysis, mermaid, javascript, nodejs, mcp, streamersonglist]
+date_created: "2025-10-12"
+last_modified: ""
+repo: "/Users/vuvu-mbp/Developer/mcp/streamersonglist-mcp"
+default_branch: "main"
+commit: "current"
+tool_version: "claude-4-sonnet@2025-10-12"
+---
+
+# StreamerSongList MCP — Code-First Architecture Report
+
+## 1. What the Code Says This Is
+
+**Purpose**: A Model Context Protocol (MCP) server that exposes read-only StreamerSongList API functionality through 6 standardized tools, enabling AI assistants to access streamer information, song queues, and music catalogs without authentication. The server implements dynamic MCP SDK loading, optional default streamer configuration, and comprehensive error handling for external API interactions.
+
+**Top Signals**:
+- **Languages**: JavaScript 100% (780 LoC excluding node_modules)
+- **Files**: 19 project files (excluding dependencies)
+- **Primary Framework**: @modelcontextprotocol/sdk v1.13.3
+- **Runtime**: Node.js ≥18.0.0
+
+**Evidence**:
+- `src/server.js:1-558` - Single-file MCP server implementation
+- `package.json:2` - Project name "streamersonglist-mcp"
+- `package.json:15-17` - Dependencies: @modelcontextprotocol/sdk, undici
+- `package-lock.json:6` - Node.js version requirement ">=18.0.0"
+
+## 2. Architecture at a Glance
+
+```mermaid
+graph TD
+    Client[MCP Client<br/>Claude Desktop] -->|JSON-RPC| Server[MCP Server<br/>src/server.js]
+    Server -->|HTTP/fetch| API[StreamerSongList API<br/>api.streamersonglist.com]
+    Server -->|stdio| Transport[StdioServerTransport]
+    
+    subgraph "MCP Tools"
+        T1[getStreamerByName]
+        T2[getQueue]
+        T3[monitorQueue]
+        T4[getSongs]
+        T5[searchSongs]
+        T6[getSongDetails]
+    end
+    
+    Server --> T1
+    Server --> T2
+    Server --> T3
+    Server --> T4
+    Server --> T5
+    Server --> T6
+    
+    T1 -->|GET /v1/streamers/{name}| API
+    T2 -->|GET /v1/streamers/{name}/queue| API
+    T3 -->|GET /v1/streamers/{name}/queue| API
+    T4 -->|GET /v1/streamers/{name}/songs| API
+    T5 -->|Client-side filter| T4
+    T6 -->|GET /v1/streamers/{name}/songs| API
+```
+
+**Trust Boundaries**: MCP protocol boundary between client and server; HTTP boundary between server and external API
+**Coupling Hotspots**: Single-file architecture creates tight coupling; external API dependency is critical path
+
+## 3. Module & Dependency Graph (Internal)
+
+```mermaid
+graph LR
+    Server[src/server.js] --> SDK[@modelcontextprotocol/sdk]
+    Server --> Undici[undici - HTTP client]
+    Server --> NodeFS[Node.js fs]
+    Server --> NodePath[Node.js path]
+    
+    subgraph "External Dependencies"
+        SDK --> Express[express]
+        SDK --> Zod[zod]
+        SDK --> AJV[ajv]
+        SDK --> CORS[cors]
+    end
+    
+    subgraph "Runtime"
+        Server --> API[StreamerSongList API<br/>External Service]
+    end
+```
+
+**High Fan-in Modules**: 
+- `src/server.js` - Central orchestrator (all tools, configuration, transport)
+- `@modelcontextprotocol/sdk` - Core MCP functionality
+
+**Cycles**: None detected (single-file architecture prevents internal cycles)
+
+## 4. Typical Execution Flow
+
+```mermaid
+sequenceDiagram
+    participant C as MCP Client
+    participant S as MCP Server
+    participant A as StreamerSongList API
+    
+    C->>S: tools/list (JSON-RPC)
+    S-->>C: Available tools response
+    
+    C->>S: tools/call getQueue
+    S->>S: Resolve streamerName (default or param)
+    S->>A: GET /v1/streamers/{name}/queue
+    A-->>S: Queue data (JSON)
+    S->>S: Transform response
+    S-->>C: Formatted queue response
+    
+    Note over S,A: Error handling for 404/500
+    Note over C,S: All communication via stdio transport
+```
+
+## 5. API Surface
+
+### MCP Tools (6 total)
+
+| Tool | Handler | File | Status |
+|------|---------|------|--------|
+| `getStreamerByName` | `src/server.js:265-285` | Working | ✅ |
+| `getQueue` | `src/server.js:295-330` | Working | ✅ |
+| `monitorQueue` | `src/server.js:340-375` | Simulated | ⚠️ |
+| `getSongs` | `src/server.js:385-420` | Working | ✅ |
+| `searchSongs` | `src/server.js:430-470` | Client-side filter | ⚠️ |
+| `getSongDetails` | `src/server.js:480-520` | Working | ✅ |
+
+### External API Endpoints (StreamerSongList)
+
+| Endpoint | Method | Status | Usage |
+|----------|--------|--------|-------|
+| `/v1/streamers/{name}` | GET | ✅ Working | `getStreamerByName` |
+| `/v1/streamers/{name}/queue` | GET | ✅ Working | `getQueue`, `monitorQueue` |
+| `/v1/streamers/{name}/songs` | GET | ✅ Working | `getSongs`, `searchSongs`, `getSongDetails` |
+
+**Evidence**: `docs/API_TESTING_REPORT.md:15-45` - Only 4 of 11+ documented endpoints functional
+
+### CLI Interface
+
+| Command | Entry Point | Purpose |
+|---------|-------------|---------|
+| `streamersonglist-mcp [streamer]` | `src/server.js:530-558` | Start MCP server with optional default streamer |
+
+## 6. Data Model (ER)
+
+```mermaid
+erDiagram
+    STREAMER ||--o{ QUEUE_ITEM : has
+    STREAMER ||--o{ SONG : owns
+    QUEUE_ITEM ||--|| SONG : references
+    SONG ||--o{ ATTRIBUTE : tagged_with
+    
+    STREAMER {
+        int id PK
+        string name
+        boolean allowDuplicates
+        boolean requestsActive
+        array attributes
+        array globalCommands
+    }
+    
+    QUEUE_ITEM {
+        int position
+        object song FK
+        string requester
+        float donation
+        string note
+        datetime createdAt
+    }
+    
+    SONG {
+        int id PK
+        string title
+        string artist
+        boolean active
+        int timesPlayed
+        datetime lastPlayed
+        float minAmount
+        array attributes
+    }
+    
+    ATTRIBUTE {
+        int id PK
+        string name
+        string color
+        boolean subscriberOnly
+    }
+```
+
+**Evidence**: 
+- `docs/API_TESTING_REPORT.md:25-40` - Streamer response structure
+- `docs/API_TESTING_REPORT.md:50-65` - Queue item structure  
+- `docs/API_TESTING_REPORT.md:70-85` - Song metadata structure
+
+## 7. Configuration & Environments
+
+### Required Environment Variables
+- **None required** - Server operates without authentication
+
+### Optional Configuration
+| Variable | Default | Source | Purpose |
+|----------|---------|--------|---------|
+| `DEFAULT_STREAMER` | `null` | ENV/CLI | Default streamer for tools when not specified |
+
+### Configuration Sources
+- `src/server.js:45-55` - CLI argument parsing for default streamer
+- `claude-desktop-config.example.json` - MCP client configuration template
+- `setup-claude.js:1-150` - Automated Claude Desktop integration
+
+### Ports & URLs
+- **No server ports** - Uses stdio transport for MCP communication
+- **External API**: `https://api.streamersonglist.com/v1/`
+
+## 8. Build • Run • Test • Deploy
+
+### Build Commands
+```bash
+# No build step required - direct Node.js execution
+npm install  # Install dependencies only
+```
+
+### Run Commands (Local)
+```bash
+# Direct execution
+node src/server.js [default-streamer]
+
+# Via npm
+npm start [-- default-streamer]
+
+# MCP client integration
+# Configure in Claude Desktop mcpServers block
+```
+
+### Testing
+```bash
+npm test  # Runs test-server.js - MCP protocol validation
+```
+**Evidence**: `test-server.js:1-50` - Spawns server, sends tools/list request
+
+### Docker/Containerization
+- **None present** - No Dockerfile or container configuration found
+
+### CI/CD Pipeline
+**GitHub Actions** (`.github/workflows/test.yml`):
+- **Triggers**: Push/PR to main branch
+- **Matrix**: Node.js 18.x, 20.x, 22.x
+- **Steps**: Checkout → Setup Node → Install → Test → Start verification
+- **No deployment** - Testing only
+
+## 9. Quality, Tests, and Security Notes
+
+### Test Coverage
+- **Protocol Testing**: `test-server.js` validates MCP server startup and tool listing
+- **API Testing**: Manual testing documented in `docs/API_TESTING_REPORT.md`
+- **No Unit Tests**: No framework-based testing (Jest, Mocha, etc.)
+- **Coverage Gaps**: Tool functionality, error handling, edge cases
+
+### Code Quality Tools
+- **Linting**: None detected (no ESLint, Prettier configs)
+- **Type Checking**: None (no TypeScript, JSDoc types)
+- **Formatting**: No automated formatting rules
+
+### Security Considerations
+
+#### ✅ Secure Practices
+- No authentication required (read-only public API)
+- Input validation via Zod schemas in MCP SDK
+- Proper URL encoding for API parameters (`src/server.js:272`)
+
+#### ⚠️ Security Risks
+- **Dependency Age**: Should audit @modelcontextprotocol/sdk dependencies
+- **Error Exposure**: API errors passed through to client (`src/server.js:280`)
+- **No Rate Limiting**: Could overwhelm external API
+- **Input Sanitization**: Limited validation beyond MCP schema
+
+#### 🔍 High-Risk Dependencies
+- `undici@7.11.0` - HTTP client (check for CVEs)
+- `express@4.x` (via MCP SDK) - Web framework vulnerabilities
+
+## 10. Contradictions & Unknowns
+
+### Documentation vs Code Mismatches
+
+1. **Tool Count Discrepancy**
+   - **README.md**: Claims 6 tools
+   - **Code Reality**: Exactly 6 tools implemented (`src/server.js:120-229`)
+   - **Status**: ✅ Consistent
+
+2. **API Functionality Claims**
+   - **README.md**: "real API data without authentication"
+   - **Code Reality**: Only 4/6 tools use real API; 2 use client-side processing
+   - **Evidence**: `docs/API_TESTING_REPORT.md:130-145` - searchSongs uses client filtering
+   - **Status**: ⚠️ Misleading
+
+3. **Tool Descriptions**
+   - **README.md**: "monitorQueue" described as real-time
+   - **Code Reality**: Returns static queue snapshot with simulation description
+   - **Evidence**: `src/server.js:340-375` - No actual monitoring implementation
+   - **Status**: ❌ Incorrect
+
+### Open Questions
+
+1. **Authentication Support**: How to enable write operations when API supports them?
+2. **Rate Limiting**: What are the actual API rate limits?
+3. **Real-time Monitoring**: Is WebSocket or polling preferred for queue monitoring?
+4. **Error Handling**: Should API errors be sanitized before client exposure?
+
+### Verification Methods
+- Test with authenticated API endpoints when available
+- Monitor API response headers for rate limit information
+- Implement WebSocket connection testing for real-time features
+
+## 11. Appendix
+
+### Full Dependency List (Top-Level)
+```json
+{
+  "@modelcontextprotocol/sdk": "1.13.3",
+  "undici": "7.11.0"
+}
+```
+
+### Directory Structure
+```
+streamersonglist-mcp/
+├── src/
+│   └── server.js                 # Main MCP server (558 lines)
+├── docs/                         # Documentation (8 files)
+├── .github/workflows/            # CI/CD configuration
+├── claude-desktop-config*.json   # Client configuration examples
+├── setup-claude.js              # Automated setup script (150 lines)
+├── test-server.js               # Protocol testing (72 lines)
+├── package.json                 # Project configuration
+├── package-lock.json            # Dependency lock
+└── README.md                    # Primary documentation
+```
+
+### Generation Parameters
+- **Analysis Date**: 2025-10-12
+- **Commit**: Current working directory state
+- **Tool Version**: Claude 4 Sonnet
+- **Analysis Method**: Static code analysis with external API validation

--- a/docs/analysis-reports/2025-10-12-streamersonglist-mcp-architecture-report.md
+++ b/docs/analysis-reports/2025-10-12-streamersonglist-mcp-architecture-report.md
@@ -19,7 +19,7 @@ tool_version: "claude-4-sonnet@2025-10-12"
 **Top Signals**:
 - **Languages**: JavaScript 100% (780 LoC excluding node_modules)
 - **Files**: 19 project files (excluding dependencies)
-- **Primary Framework**: @modelcontextprotocol/sdk v1.13.3
+- **Primary Framework**: @modelcontextprotocol/sdk (project now depends on ^1.20.0)
 - **Runtime**: Node.js ≥18.0.0
 
 **Evidence**:
@@ -27,6 +27,8 @@ tool_version: "claude-4-sonnet@2025-10-12"
 - `package.json:2` - Project name "streamersonglist-mcp"
 - `package.json:15-17` - Dependencies: @modelcontextprotocol/sdk, undici
 - `package-lock.json:6` - Node.js version requirement ">=18.0.0"
+
+> Note: This report is a snapshot from 2025-10-12. Current package versions: `@modelcontextprotocol/sdk@^1.20.0`, `undici@^7.16.0`. API base is configurable via `SSL_API_BASE` (default `https://api.streamersonglist.com/v1`).
 
 ## 2. Architecture at a Glance
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,8 @@
       "version": "1.2.1",
       "license": "MIT",
       "dependencies": {
-        "@modelcontextprotocol/sdk": "^1.13.3",
-        "undici": "^7.11.0"
+        "@modelcontextprotocol/sdk": "^1.20.0",
+        "undici": "^7.16.0"
       },
       "bin": {
         "streamersonglist-mcp": "src/server.js"
@@ -20,9 +20,9 @@
       }
     },
     "node_modules/@modelcontextprotocol/sdk": {
-      "version": "1.13.3",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.13.3.tgz",
-      "integrity": "sha512-bGwA78F/U5G2jrnsdRkPY3IwIwZeWUEfb5o764b79lb0rJmMT76TLwKhdNZOWakOQtedYefwIR4emisEMvInKA==",
+      "version": "1.20.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.20.0.tgz",
+      "integrity": "sha512-kOQ4+fHuT4KbR2iq2IjeV32HiihueuOf1vJkq18z08CLZ1UQrTc8BXJpVfxZkq45+inLLD+D4xx4nBjUelJa4Q==",
       "license": "MIT",
       "dependencies": {
         "ajv": "^6.12.6",
@@ -988,9 +988,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "7.11.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.11.0.tgz",
-      "integrity": "sha512-heTSIac3iLhsmZhUCjyS3JQEkZELateufzZuBaVM5RHXdSBMb1LPMQf5x+FH7qjsZYDP0ttAc3nnVpUB+wYbOg==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.16.0.tgz",
+      "integrity": "sha512-QEg3HPMll0o3t2ourKwOeUAZ159Kn9mx5pnzHRQO8+Wixmh88YdZRiIwat0iNzNNXn0yoEtXJqFpyW7eM8BV7g==",
       "license": "MIT",
       "engines": {
         "node": ">=20.18.1"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "streamersonglist-mcp",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "streamersonglist-mcp",
-      "version": "1.2.1",
+      "version": "1.3.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.20.0",

--- a/package.json
+++ b/package.json
@@ -27,8 +27,8 @@
   "author": "vuvuvu",
   "license": "MIT",
   "dependencies": {
-    "@modelcontextprotocol/sdk": "^1.13.3",
-    "undici": "^7.11.0"
+    "@modelcontextprotocol/sdk": "^1.20.0",
+    "undici": "^7.16.0"
   },
   "engines": {
     "node": ">=18.0.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "streamersonglist-mcp",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "description": "A Model Context Protocol (MCP) server for interacting with StreamerSongList APIs",
   "main": "src/server.js",
   "bin": {

--- a/src/server.js
+++ b/src/server.js
@@ -192,6 +192,71 @@ const tools = [
       required: [],
     },
   },
+  {
+    name: "getSongs",
+    description: "Fetch the complete song list for a streamer with pagination support",
+    inputSchema: {
+      type: "object",
+      properties: {
+        streamerName: {
+          type: "string",
+          description: "The name of the streamer whose song list to fetch",
+        },
+        limit: {
+          type: "number",
+          description: "Maximum number of songs to return (default: 100)",
+          default: 100,
+        },
+        offset: {
+          type: "number",
+          description: "Number of songs to skip for pagination (default: 0)",
+          default: 0,
+        },
+      },
+      required: [],
+    },
+  },
+  {
+    name: "searchSongs",
+    description: "Search within a streamer's song list by title or artist",
+    inputSchema: {
+      type: "object",
+      properties: {
+        streamerName: {
+          type: "string",
+          description: "The name of the streamer whose songs to search",
+        },
+        query: {
+          type: "string",
+          description: "Search query to match against song titles and artists",
+        },
+        limit: {
+          type: "number",
+          description: "Maximum number of results to return (default: 20)",
+          default: 20,
+        },
+      },
+      required: ["query"],
+    },
+  },
+  {
+    name: "getSongDetails",
+    description: "Get detailed information about a specific song by ID",
+    inputSchema: {
+      type: "object",
+      properties: {
+        streamerName: {
+          type: "string",
+          description: "The name of the streamer who owns the song",
+        },
+        songId: {
+          type: "number",
+          description: "The ID of the song to fetch details for",
+        },
+      },
+      required: ["songId"],
+    },
+  },
 ];
 
 // List tools handler
@@ -377,6 +442,152 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
             content: [{
               type: "text",
               text: `Error setting up monitoring: ${error instanceof Error ? error.message : 'Unknown error'}`
+            }]
+          };
+        }
+      }
+
+      case "getSongs": {
+        const { streamerName = defaultStreamer, limit = 100, offset = 0 } = args;
+
+        if (!streamerName) {
+          throw new Error(
+            "streamerName is required. Provide a streamerName or set the DEFAULT_STREAMER environment variable."
+          );
+        }
+
+        try {
+          const response = await fetch(`https://api.streamersonglist.com/v1/streamers/${encodeURIComponent(streamerName)}/songs?limit=${limit}&offset=${offset}`);
+
+          if (!response.ok) {
+            return {
+              content: [{
+                type: "text",
+                text: `Error fetching song list: ${response.status} ${response.statusText}`
+              }]
+            };
+          }
+
+          const songsData = await response.json();
+          return {
+            content: [{
+              type: "text",
+              text: JSON.stringify(songsData, null, 2)
+            }]
+          };
+        } catch (error) {
+          return {
+            content: [{
+              type: "text",
+              text: `Error: ${error instanceof Error ? error.message : 'Unknown error'}`
+            }]
+          };
+        }
+      }
+
+      case "searchSongs": {
+        const { streamerName = defaultStreamer, query, limit = 20 } = args;
+
+        if (!streamerName) {
+          throw new Error(
+            "streamerName is required. Provide a streamerName or set the DEFAULT_STREAMER environment variable."
+          );
+        }
+
+        if (!query) {
+          throw new Error("query is required for song search");
+        }
+
+        try {
+          // First get all songs, then filter locally
+          const response = await fetch(`https://api.streamersonglist.com/v1/streamers/${encodeURIComponent(streamerName)}/songs?limit=1000`);
+
+          if (!response.ok) {
+            return {
+              content: [{
+                type: "text",
+                text: `Error fetching songs for search: ${response.status} ${response.statusText}`
+              }]
+            };
+          }
+
+          const songsData = await response.json();
+          const allSongs = songsData.items || songsData; // Handle different response formats
+          const searchQuery = query.toLowerCase();
+
+          // Filter songs by title or artist
+          const filteredSongs = allSongs.filter(song => {
+            const title = (song.title || '').toLowerCase();
+            const artist = (song.artist || '').toLowerCase();
+            return title.includes(searchQuery) || artist.includes(searchQuery);
+          }).slice(0, limit);
+
+          return {
+            content: [{
+              type: "text",
+              text: `Found ${filteredSongs.length} songs matching "${query}":\n${JSON.stringify(filteredSongs, null, 2)}`
+            }]
+          };
+        } catch (error) {
+          return {
+            content: [{
+              type: "text",
+              text: `Error: ${error instanceof Error ? error.message : 'Unknown error'}`
+            }]
+          };
+        }
+      }
+
+      case "getSongDetails": {
+        const { streamerName = defaultStreamer, songId } = args;
+
+        if (!streamerName) {
+          throw new Error(
+            "streamerName is required. Provide a streamerName or set the DEFAULT_STREAMER environment variable."
+          );
+        }
+
+        if (!songId) {
+          throw new Error("songId is required");
+        }
+
+        try {
+          // Get all songs and find the specific one
+          const response = await fetch(`https://api.streamersonglist.com/v1/streamers/${encodeURIComponent(streamerName)}/songs`);
+
+          if (!response.ok) {
+            return {
+              content: [{
+                type: "text",
+                text: `Error fetching songs: ${response.status} ${response.statusText}`
+              }]
+            };
+          }
+
+          const songsData = await response.json();
+          const allSongs = songsData.items || songsData; // Handle different response formats
+          const song = allSongs.find(s => s.id === songId);
+
+          if (!song) {
+            return {
+              content: [{
+                type: "text",
+                text: `Song with ID ${songId} not found for streamer ${streamerName}`
+              }]
+            };
+          }
+
+          return {
+            content: [{
+              type: "text",
+              text: JSON.stringify(song, null, 2)
+            }]
+          };
+        } catch (error) {
+          return {
+            content: [{
+              type: "text",
+              text: `Error: ${error instanceof Error ? error.message : 'Unknown error'}`
             }]
           };
         }

--- a/src/server.js
+++ b/src/server.js
@@ -154,21 +154,7 @@ const tools = [
       required: [],
     },
   },
-  {
-    name: "getQueueStats",
-    description: "Get comprehensive stats about song queues including total songs, duration, and popular tracks",
-    inputSchema: {
-      type: "object",
-      properties: {
-        streamerName: {
-          type: "string",
-          description: "The name of the streamer whose queue stats to fetch",
-        },
-      },
-      required: [],
-    },
-  },
-  {
+    {
     name: "monitorQueue",
     description: "Monitor queue changes with configurable polling intervals",
     inputSchema: {
@@ -337,54 +323,6 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
             content: [{
               type: "text",
               text: JSON.stringify(queueData, null, 2)
-            }]
-          };
-        } catch (error) {
-          return {
-            content: [{
-              type: "text",
-              text: `Error: ${error instanceof Error ? error.message : 'Unknown error'}`
-            }]
-          };
-        }
-      }
-
-      case "getQueueStats": {
-        const { streamerName = defaultStreamer } = args;
-
-        if (!streamerName) {
-          throw new Error(
-            "streamerName is required. Provide a streamerName or set the DEFAULT_STREAMER environment variable."
-          );
-        }
-        
-        try {
-          const response = await fetch(`https://api.streamersonglist.com/v1/streamers/${encodeURIComponent(streamerName)}/queue/stats`);
-          
-          if (!response.ok) {
-            return {
-              content: [{
-                type: "text",
-                text: `Error fetching queue stats: ${response.status} ${response.statusText}`
-              }]
-            };
-          }
-          
-          const statsData = await response.json();
-          
-          const summary = {
-            totalSongs: statsData.totalSongs || 0,
-            totalDuration: statsData.totalDuration || 0,
-            averageWaitTime: statsData.averageWaitTime || 0,
-            mostRequestedArtist: statsData.mostRequestedArtist || 'N/A',
-            mostRequestedSong: statsData.mostRequestedSong || 'N/A',
-            queueStatus: statsData.queueStatus || 'unknown'
-          };
-          
-          return {
-            content: [{
-              type: "text",
-              text: `Queue Statistics for ${streamerName}:\n${JSON.stringify(summary, null, 2)}`
             }]
           };
         } catch (error) {

--- a/src/server.js
+++ b/src/server.js
@@ -7,6 +7,12 @@ globalThis.fetch = fetch;
 // Import required modules
 const path = require('path');
 const fs = require('fs');
+const pkg = require('../package.json');
+
+// Derive runtime metadata and configuration from package.json / env
+const PACKAGE_VERSION = pkg.version || '0.0.0';
+const SDK_DEP_RANGE = (pkg.dependencies && pkg.dependencies['@modelcontextprotocol/sdk']) || '';
+const API_BASE = process.env.SSL_API_BASE || 'https://api.streamersonglist.com/v1';
 
 // Function to find the MCP SDK
 function findMcpSdk() {
@@ -62,8 +68,9 @@ try {
   global.ListToolsRequestSchema = sdk.ListToolsRequestSchema;
 } catch (error) {
   console.error("Error loading MCP SDK:", error.message);
-  console.error("Please install the MCP SDK with: npm install @modelcontextprotocol/sdk@1.13.3");
-  console.error("If the error persists, try installing the package globally: npm install -g @modelcontextprotocol/sdk@1.13.3");
+  const sdkHint = SDK_DEP_RANGE || 'latest';
+  console.error(`Please install the MCP SDK with: npm install @modelcontextprotocol/sdk@${sdkHint}`);
+  console.error(`If the error persists, try installing the package globally: npm install -g @modelcontextprotocol/sdk@${sdkHint}`);
   process.exit(1);
 }
 
@@ -105,7 +112,7 @@ let defaultStreamer = process.env.DEFAULT_STREAMER || null;
 const server = new global.Server(
   {
     name: "streamersonglist-mcp",
-    version: "1.1.0",
+    version: PACKAGE_VERSION,
   },
   {
     capabilities: {
@@ -269,7 +276,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         }
         
         try {
-          const response = await fetch(`https://api.streamersonglist.com/v1/streamers/${encodeURIComponent(streamerName)}`);
+          const response = await fetch(`${API_BASE}/streamers/${encodeURIComponent(streamerName)}`);
           
           if (!response.ok) {
             return {
@@ -307,7 +314,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         }
         
         try {
-          const response = await fetch(`https://api.streamersonglist.com/v1/streamers/${encodeURIComponent(streamerName)}/queue?limit=${limit}&offset=${offset}`);
+          const response = await fetch(`${API_BASE}/streamers/${encodeURIComponent(streamerName)}/queue?limit=${limit}&offset=${offset}`);
           
           if (!response.ok) {
             return {
@@ -395,7 +402,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         }
 
         try {
-          const response = await fetch(`https://api.streamersonglist.com/v1/streamers/${encodeURIComponent(streamerName)}/songs?limit=${limit}&offset=${offset}`);
+          const response = await fetch(`${API_BASE}/streamers/${encodeURIComponent(streamerName)}/songs?limit=${limit}&offset=${offset}`);
 
           if (!response.ok) {
             return {
@@ -438,7 +445,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
 
         try {
           // First get all songs, then filter locally
-          const response = await fetch(`https://api.streamersonglist.com/v1/streamers/${encodeURIComponent(streamerName)}/songs?limit=1000`);
+          const response = await fetch(`${API_BASE}/streamers/${encodeURIComponent(streamerName)}/songs?limit=1000`);
 
           if (!response.ok) {
             return {
@@ -491,7 +498,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
 
         try {
           // Get all songs and find the specific one
-          const response = await fetch(`https://api.streamersonglist.com/v1/streamers/${encodeURIComponent(streamerName)}/songs`);
+          const response = await fetch(`${API_BASE}/streamers/${encodeURIComponent(streamerName)}/songs`);
 
           if (!response.ok) {
             return {

--- a/src/server.js
+++ b/src/server.js
@@ -1,8 +1,10 @@
 #!/usr/bin/env node
 
-// Add fetch polyfill for Node.js environments
-const { fetch } = require('undici');
-globalThis.fetch = fetch;
+// Use Node's built-in fetch (Node >= 18). Fail fast if missing.
+if (typeof globalThis.fetch !== 'function') {
+  console.error('Error: global fetch not found. Node.js 18+ is required.');
+  process.exit(1);
+}
 
 // Import required modules
 const path = require('path');


### PR DESCRIPTION
Summary
- Refresh public docs and add Contributing/Credits for public use.
- Derive runtime version from package.json and centralize API base via SSL_API_BASE.
- Remove outdated references (e.g., non-existent getQueueStats) and align dependency mentions.

Changes
- src/server.js
  - Read version from package.json (no hardcoded 1.1.0)
  - Use SDK dependency range from package.json for install hints
  - Centralize API base (SSL_API_BASE; default https://api.streamersonglist.com/v1)
  - Replace inline endpoint strings with API_BASE
- README.md
  - Document SSL_API_BASE and version reporting
  - Add Contributing and Credits (acknowledge https://www.streamersonglist.com; non-affiliation note)
- CLAUDE.md
  - Update dependency versions and tool list; add SSL_API_BASE
- docs/README.md
  - Clean up index, add Contributing & Credits section
- docs/USAGE_EXAMPLES.md
  - Remove getQueueStats references; suggest getQueue/monitorQueue for analytics
- docs/API_TESTING_REPORT.md
  - Clarify getQueueStats is not implemented; upstream 404
- docs/analysis-reports/2025-10-12-streamersonglist-mcp-architecture-report.md
  - Snapshot note with current deps and SSL_API_BASE

Why
- Eliminate hardcoded mismatches and make configuration explicit.
- Keep public docs accurate, concise, and respectful of API limits.

Testing
- npm test passes locally (server starts, tools/list works)
- Inspector command works: `npx @modelcontextprotocol/inspector@latest -- npx streamersonglist-mcp`

Release
- v1.3.0 is published to npm and tagged.
- These changes are post-1.3.0; if merged, we can cut v1.3.1 (patch) and publish.

Notes
- New env: SSL_API_BASE (optional override)
- Scope note: API is public/read-only, so feature surface is intentionally modest.